### PR TITLE
Integrating with hosted Observability services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ busy_beaver.db
 .git
 .vscode
 .envrc
+.travis.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ busy_beaver.db
 .vscode
 .envrc
 .travis.yml
+logs/
+creds.txt

--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,6 @@ ENV/
 .vscode
 
 # local development files
+logs/
 busy_beaver.db
 creds.txt

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ $ python scripts/ipython_shell.py
   - [ ] mark events that are new
 - [ ] [rate limiting](https://developer.github.com/v3/#rate-limiting)
 - [ ] [GraphQL](https://developer.github.com/v4/)
-- [ ] logging (grab `LOGGING_CONFIG` from other projects)
 - [ ] use sqlite memory for tests
 
 ## Scratchpad

--- a/busy_beaver/__init__.py
+++ b/busy_beaver/__init__.py
@@ -1,7 +1,20 @@
+import logging
+import logging.config
+
+import responder
+import sentry_sdk
 from sqlalchemy_wrapper import SQLAlchemy
 
-from .config import DATABASE_URI
+from .config import DATABASE_URI, IN_PRODUCTION, LOGGING_CONFIG, SENTRY_DSN
+
+# observability
+logging.config.dictConfig(LOGGING_CONFIG)
+if IN_PRODUCTION and SENTRY_DSN:
+    sentry_sdk.init(SENTRY_DSN)
 
 
+# web app
+api = responder.API()
 db = SQLAlchemy(DATABASE_URI)
 from . import models  # noqa
+from . import backend  # noqa

--- a/busy_beaver/__init__.py
+++ b/busy_beaver/__init__.py
@@ -9,11 +9,12 @@ from .config import DATABASE_URI, IN_PRODUCTION, LOGGING_CONFIG, SENTRY_DSN
 
 # observability
 logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger(__name__)
 if IN_PRODUCTION and SENTRY_DSN:
     sentry_sdk.init(SENTRY_DSN)
 
-
 # web app
+logger.info("[BusyBeaver] Starting Server")
 api = responder.API()
 db = SQLAlchemy(DATABASE_URI)
 from . import models  # noqa

--- a/busy_beaver/backend.py
+++ b/busy_beaver/backend.py
@@ -35,7 +35,7 @@ class HelloWorldResource:
     """For testing purposes"""
 
     def on_get(self, req, resp):
-        logger.info("[Busy-Beaver] Hit hello world endpoint")
+        logger.info("[Busy-Beaver] Hit hello world endpoint", extra={"test": "payload"})
         resp.media = {"Hello": "World"}
 
 

--- a/busy_beaver/backend.py
+++ b/busy_beaver/backend.py
@@ -5,6 +5,7 @@ import uuid
 
 import requests
 import responder
+import sentry_sdk
 
 from . import db
 from .models import User
@@ -30,6 +31,7 @@ def debug(s=2, *, data):
 
 class HelloWorldResource:
     """For testing purposes"""
+
     def on_get(self, req, resp):
         resp.media = {"Hello": "World"}
 
@@ -66,28 +68,22 @@ def reply_to_user_with_github_login_link(event):
     channel = event["channel"]
 
     if chat_text not in ["link me", "link me again"]:
-        slack.post_message(
-            channel,
-            (
-                "Hi! I don't recognize that command. "
-                "Type `link me` to validate your GitHub account."
-            ),
+        msg = (
+            "Hi! I don't recognize that command. "
+            "Type `link me` to validate your GitHub account."
         )
+        slack.post_message(channel, msg)
         return
 
     user_record = db.query(User).filter_by(slack_id=slack_id).first()
-
     if user_record and chat_text == "link me":
-        slack.post_message(
-            channel,
-            (
-                "I already sent you an activation link. "
-                "If you've misplaced it, "
-                "type `link me again`. To change your account associations, "
-                "contact an administrator."
-            ),
+        msg = (
+            "I already sent you an activation link. "
+            "If you've misplaced it, "
+            "type `link me again`. To change your account associations, "
+            "contact an administrator."
         )
-        print("already exists")
+        slack.post_message(channel, msg)
         return
 
     if user_record and chat_text == "link me again":
@@ -108,7 +104,6 @@ def reply_to_user_with_github_login_link(event):
     query_params = urlencode(data)
     url = f"https://github.com/login/oauth/authorize?{query_params}"
     slack.post_message(channel, url)
-
     return
 
 
@@ -116,7 +111,7 @@ def reply_to_user_with_github_login_link(event):
 # GitHub
 ########
 class GitHubIntegrationResource:
-    async def on_get(self, req, resp):
+    def on_get(self, req, resp):
         params = req.params
         code = params.get("code")
         state = params.get("state")

--- a/busy_beaver/backend.py
+++ b/busy_beaver/backend.py
@@ -1,15 +1,16 @@
 import os
+import logging
 import time
 from urllib.parse import urlencode
 import uuid
 
 import requests
-import responder
-import sentry_sdk
 
-from . import db
+from . import api, db
 from .models import User
 from .adapters.slack import SlackAdapter
+
+logger = logging.getLogger(__name__)
 
 CLIENT_ID = os.getenv("GITHUB_APP_CLIENT_ID")
 CLIENT_SECRET = os.getenv("GITHUB_APP_CLIENT_SECRET")
@@ -19,9 +20,10 @@ SLACK_CALLBACK_URI = "https://busybeaver.sivji.com/slack-event-subscription"
 SLACK_TOKEN = os.getenv("SLACK_BOTUSER_OAUTH_TOKEN")
 slack = SlackAdapter(SLACK_TOKEN)
 
-api = responder.API()
 
-
+#########
+# Sandbox
+#########
 @api.background.task
 def debug(s=2, *, data):
     time.sleep(s)
@@ -33,6 +35,7 @@ class HelloWorldResource:
     """For testing purposes"""
 
     def on_get(self, req, resp):
+        logger.info("[Busy-Beaver] Hit hello world endpoint")
         resp.media = {"Hello": "World"}
 
 

--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -8,3 +8,36 @@ DATABASE_URI = os.getenv("DATABASE_URI", local_db)
 
 # credentials
 oauth_token = os.getenv("GITHUB_OAUTH_TOKEN")
+
+# observability
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "[%(asctime)s] %(name)s:%(lineno)s %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        },
+        "json": {
+            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "format": "%(asctime)s %(name)s %(lineno)s %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        },
+    },
+    "handlers": {
+        "console": {"class": "logging.StreamHandler", "formatter": "standard"},
+        "datadog_file": {
+            "class": "logging.FileHandler",
+            "filename": "busy_beaver_log.json",
+            "mode": "w",
+            "formatter": "json",
+        },
+    },
+    "loggers": {
+        "busy_beaver": {
+            "handlers": ["console", "datadog_file"],
+            "level": "INFO" if IN_PRODUCTION else "DEBUG",
+        }
+    },
+}
+SENTRY_DSN = os.getenv("SENTRY_DSN", None)

--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -20,22 +20,21 @@ LOGGING_CONFIG = {
         },
         "json": {
             "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
-            "format": "%(asctime)s %(name)s %(lineno)s %(message)s",
-            "datefmt": "%Y-%m-%d %H:%M:%S",
+            "format": "%(asctime)s %(filename)s %(funcName)s %(lineno)s %(message)s",
         },
     },
     "handlers": {
         "console": {"class": "logging.StreamHandler", "formatter": "standard"},
         "datadog_file": {
             "class": "logging.FileHandler",
-            "filename": "busy_beaver_log.json",
+            "filename": "logs/busy_beaver_log.json",
             "mode": "w",
             "formatter": "json",
         },
     },
     "loggers": {
         "busy_beaver": {
-            "handlers": ["console", "datadog_file"],
+            "handlers": ["datadog_file"] if IN_PRODUCTION else ["console"],
             "level": "INFO" if IN_PRODUCTION else "DEBUG",
         }
     },

--- a/datadog/Dockerfile
+++ b/datadog/Dockerfile
@@ -1,0 +1,2 @@
+FROM datadog/agent:latest
+ADD conf.d/python.d/conf.yaml /etc/datadog-agent/conf.d/python.d/conf.yaml

--- a/datadog/conf.d/python.d/conf.yaml
+++ b/datadog/conf.d/python.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+ - type: file
+   path: /busy-beaver/logs/busy_beaver_log.json
+   service: busy-beaver
+   source: python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   app:
     build:
       context: .
-    command: ["uvicorn", "busy_beaver.backend:api", "--host", "0.0.0.0", "--port", "5100"]
+    command: ["uvicorn", "busy_beaver:api", "--host", "0.0.0.0", "--port", "5100"]
     environment:
       PYTHONPATH: .
       DATABASE_URI: sqlite:////app/busy_beaver.db
@@ -19,10 +19,33 @@ services:
     stdin_open: true
     tty: true
     volumes:
+      # TODO remove app volume in production
       - .:/app/
+      - ./logs:/app/logs/
     networks:
       - sivnet
     labels:
       - traefik.enable=true
       - traefik.backend=busybeaver
       - traefik.frontend.rule=Host:busybeaver.sivji.com
+  # agents
+  # TODO enable for production only
+  # datadog:
+  #   build: datadog
+  #   depends_on:
+  #     - app
+  #   links:
+  #     - app
+  #   environment:
+  #     - DD_API_KEY=${DATADOG_API_KEY}
+  #     - DD_HOSTNAME=busybeaver.sivji.com
+  #     - DD_LOGS_ENABLED=true
+  #     - DD_ENABLE_PAYLOADS_EVENTS=false
+  #     - DD_ENABLE_PAYLOADS_SERIES=false
+  #     - DD_ENABLE_PAYLOADS_SERVICE_CHECKS=false
+  #     - DD_ENABLE_PAYLOADS_SKETCHES=false
+  #   volumes:
+  #     - ./logs:/busy-beaver/logs
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #     - /proc/:/host/proc/:ro
+  #     - /sys/fs/cgroup:/host/sys/fs/cgroup:ro

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 alembic==1.0.3
 python-dateutil==2.7.5
+python-json-logger==0.1.10
 pytz==2018.7
 requests==2.20.1
-responder
-slackclient
+responder==1.1.2
+sentry-sdk==0.6.2
+slackclient==1.3.0
 SQLAlchemy-Wrapper==1.9.1
 SQLAlchemy==1.2.14
 starlette==0.8.8
-uvicorn
+uvicorn==0.3.21


### PR DESCRIPTION
Namely, [Datadog](https://datadoghq.com) and [Sentry](https://sentry.io). Podcast ads do work.

Copied my `logging` config from another project; changed log record format via [python-json-logger](https://github.com/madzak/python-json-logger)

Datadog has a really cheap plan (~$2/month for 1 million logs) so I decided to go all in. I've used Sentry at previous jobs and love how much information you get along with the traceback.

#### Resources

- [Python log collection](https://docs.datadoghq.com/logs/log_collection/python/)
- [Datadog Docker-Compose example repo](https://github.com/DataDog/docker-compose-example)
- [Use Datadog Agent to only send logs](https://docs.datadoghq.com/logs/faq/can-the-datadog-agent-be-used-to-send-only-logs/?tab=environmentvariables)
- [Integrating Sentry with Python Standard Library Logging](https://docs.sentry.io/platforms/python/logging/)