### PR TITLE
Send headers in request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,11 @@ test-skipvcr:
 lint:
 	docker-compose exec app flake8
 
-ipython:
-	docker-compose exec app ipython -i scripts/dev_shell.py
-
 shell:
 	docker-compose exec app bash
+
+shell-dev:
+	docker-compose exec app ipython -i scripts/dev_shell.py
 
 # serve:
 # 	uvicorn busy_beaver.backend:api --host 0.0.0.0 --port 5100 --debug

--- a/busy_beaver/adapters/github.py
+++ b/busy_beaver/adapters/github.py
@@ -21,8 +21,6 @@ class GitHubAdapter:
         self.headers = {
             "Accept": "application/vnd.github.v3+json",
             "Authorization": f"token {oauth_token}",
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
         }
         self.params = {"per_page": 30}
         self.nav = None
@@ -34,13 +32,13 @@ class GitHubAdapter:
     # Adapter-Client
     ################
     def __get(self, url: str, **kwargs) -> Response:
-        resp = self.client.get(url, **kwargs)
+        resp = self.client.get(url, headers=self.headers, **kwargs)
         if resp.status_code != 200:
             raise UnexpectedStatusCode
         return resp
 
     def __head(self, url: str, **kwargs) -> Response:
-        resp = self.client.head(url, **kwargs)
+        resp = self.client.head(url, headers=self.headers, **kwargs)
         if resp.status_code != 200:
             raise UnexpectedStatusCode
         return resp

--- a/busy_beaver/adapters/requests_client.py
+++ b/busy_beaver/adapters/requests_client.py
@@ -16,13 +16,22 @@ class Response(NamedTuple):
 class RequestsClient:
     def __init__(self):
         s = requests.Session()
+        self.headers = {
+            "User-Agent": "BusyBeaver",
+            "Content-Type": "application/json",
+        }
         self.session = s
 
     def __repr__(self):
         return "RequestsClient"
 
     def _request(self, method: str, url: str, **kwargs) -> Response:
-        r = self.session.request(method, url, **kwargs)
+        req_headers = self.headers.copy()
+        if "headers" in kwargs:
+            headers_to_add = kwargs.pop("headers")
+            req_headers.update(headers_to_add)
+
+        r = self.session.request(method, url, headers=req_headers, **kwargs)
         r.raise_for_status()
 
         try:


### PR DESCRIPTION
When we restructured the project in #4, the headers got lost in the shuffle. This PR starts to include headers with requests as is expected behavior.