### PR TITLE
Travis CI/CD integration to deploy image artifact to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ deploy:
   script:
     - docker push ${IMAGE_NAME} && docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
   on:
-    branch: cicd-final-cleanup
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,18 @@ python:
 install:
   - pip install -r requirements_dev.txt
 
-before_script:
-  - docker pull ${IMAGE_NAME}:latest || true
-
-# run test
 script:
   - alembic --config=./migrations/alembic.ini upgrade head
   - pytest --cov=./
   - flake8
-  - docker build --pull --cache-from ${IMAGE_NAME}:latest --tag ${IMAGE_NAME} --tag ${IMAGE_NAME}:${TRAVIS_COMMIT} .
 
 before_deploy:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 deploy:
   provider: script
   script:
-    - docker push ${IMAGE_NAME}:latest && docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
-  on:
-    branch: master
+    - docker pull ${IMAGE_NAME} || true
+    - docker build --pull --cache-from ${IMAGE_NAME} --tag ${IMAGE_NAME} --tag ${IMAGE_NAME}:${TRAVIS_COMMIT} .
+    - docker push ${IMAGE_NAME} && docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
+  # on:
+  #   branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ deploy:
     - docker pull ${IMAGE_NAME} || true
     - docker build --pull --cache-from ${IMAGE_NAME} --tag ${IMAGE_NAME} --tag ${IMAGE_NAME}:${TRAVIS_COMMIT} .
     - docker push ${IMAGE_NAME} && docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
-  # on:
-  #   branch: master
+  on:
+    branch: cicd-final-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ script:
 
 before_deploy:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - docker pull ${IMAGE_NAME} || true
+  - docker build --pull --cache-from ${IMAGE_NAME} --tag ${IMAGE_NAME} --tag ${IMAGE_NAME}:${TRAVIS_COMMIT} .
 deploy:
   provider: script
   script:
-    - docker pull ${IMAGE_NAME} || true
-    - docker build --pull --cache-from ${IMAGE_NAME} --tag ${IMAGE_NAME} --tag ${IMAGE_NAME}:${TRAVIS_COMMIT} .
     - docker push ${IMAGE_NAME} && docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
   on:
     branch: cicd-final-cleanup


### PR DESCRIPTION
Close #13. Also with help from #18 and #19 as I was figuring the process out.

#### Final .travis.yml

```yaml
notifications:
  email: false
sudo: required

env:
  - PYTHONPATH=. DATABASE_URI="sqlite:///busy_beaver.db" IMAGE_NAME="alysivji/busy-beaver"

# python settings
language: python
sudo: required
dist: xenial
python:
  - "3.7"

install:
  - pip install -r requirements_dev.txt

script:
  - alembic --config=./migrations/alembic.ini upgrade head
  - pytest --cov=./
  - flake8

before_deploy:
  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
  - docker pull ${IMAGE_NAME} || true
  - docker build --pull --cache-from ${IMAGE_NAME} --tag ${IMAGE_NAME} --tag ${IMAGE_NAME}:${TRAVIS_COMMIT} .
deploy:
  provider: script
  script:
    - docker push ${IMAGE_NAME} && docker push ${IMAGE_NAME}:${TRAVIS_COMMIT}
  on:
    branch: master
```

#### Resources
- [Travis docs -- job lifecycle](https://docs.travis-ci.com/user/job-lifecycle/)
- [Travis docs -- sharing a Docker image](https://docs.travis-ci.com/user/build-stages/share-docker-image/)
- [Travis docs -- conditional releases](https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on)
- [Coding Tips: Patterns for Continuous Integration with Docker on Travis CI](https://medium.com/mobileforgood/coding-tips-patterns-for-continuous-integration-with-docker-on-travis-ci-9cedb8348a62)
- [Pushing Docker images right from Travis-CI](https://ops.tips/blog/travis-ci-push-docker-image/)