### PR TITLE
fix repo urls and add validation button

### DIFF
--- a/busy_beaver/backend.py
+++ b/busy_beaver/backend.py
@@ -79,6 +79,7 @@ ACCOUNT_ASSOCIATE_MSG = (
     "I'll reference your GitHub username to track your public activity."
 )
 
+
 @api.background.task
 def reply_to_user_with_github_login_link(event):
     chat_text = str.lower(event["text"])

--- a/busy_beaver/backend.py
+++ b/busy_beaver/backend.py
@@ -1,5 +1,6 @@
-import os
+import json
 import logging
+import os
 import time
 from urllib.parse import urlencode
 import uuid
@@ -68,12 +69,15 @@ SEND_LINK_COMMANDS = ["connect"]
 RESEND_LINK_COMMANDS = ["reconnect"]
 ALL_LINK_COMMANDS = SEND_LINK_COMMANDS + RESEND_LINK_COMMANDS
 
-UNKNOWN_COMMAND_MSG = "Don't recognize your command. Type `connect` link your GitHub."
+UNKNOWN_COMMAND_MSG = "I don't recognize your command. Type `connect` to link your GitHub account."
 ACCOUNT_ALREADY_ASSOCIATED_MSG = (
     "You have already associated a GitHub account with your Slack handle. "
     "Please type `reconnect` to link to a different account."
 )
-
+ACCOUNT_ASSOCIATE_MSG = (
+    "Follow the link below to validate your GitHub account. "
+    "I'll reference your GitHub username to track your public activity."
+)
 
 @api.background.task
 def reply_to_user_with_github_login_link(event):
@@ -111,7 +115,23 @@ def reply_to_user_with_github_login_link(event):
     data = {"client_id": CLIENT_ID, "redirect_uri": GITHUB_REDIRECT_URI, "state": state}
     query_params = urlencode(data)
     url = f"https://github.com/login/oauth/authorize?{query_params}"
-    slack.post_message(channel, url)
+    post_text = {
+        "text": ACCOUNT_ASSOCIATE_MSG,
+        "attachments": [
+            {
+                "fallback": url,
+                "attachment_type": "default",
+                "actions": [
+                    {
+                        "text": "Associate GitHub Profile",
+                        "type": "button",
+                        "url": url
+                    }
+                ]
+            }
+        ]
+    }
+    slack.post_message(channel, json.dumps(post_text))
     return
 
 

--- a/busy_beaver/github_stats.py
+++ b/busy_beaver/github_stats.py
@@ -18,9 +18,13 @@ def recent_activity_text(user: User):
         if event["type"] in ["PushEvent", "WatchEvent"]:
             event_of_interest = {}
             event_of_interest["type"] = event["type"]
-            event_of_interest[
-                "repo"
-            ] = f"<{event['repo']['url']}|{event['repo']['name']}>"
+            repo_url = event['repo']['url']
+            repo_url = repo_url.replace(
+                "https://api.github.com/repos/",
+                "https://www.github.com/"
+            )
+            repo_name = event['repo']['name']
+            event_of_interest["repo"] = f"<{repo_url}|{repo_name}>"
 
             if event["type"] == "PushEvent":
                 event_of_interest["commit_count"] = len(event["payload"]["commits"])
@@ -28,7 +32,10 @@ def recent_activity_text(user: User):
             events_of_interest.append(event_of_interest)
 
     if len(events_of_interest) > 1:
-        text = f"<@{user.slack_id}> as <https://github.com/{user.github_username}>\n"
+        text = (
+            f"<@{user.slack_id}> as <https://github.com/{user.github_username}|"
+            f"{user.github_username}>\n"
+        )
         for event_type in sorted(list(set([e["type"] for e in events_of_interest]))):
             events = [
                 event for event in events_of_interest if event["type"] == event_type


### PR DESCRIPTION
Repositories now appear as a hyperlink with the repo name displayed. Repository url has been fixed to lead to the repository rather than api. Account validation now provides a button.