### PR TITLE
Closes #54. When no github activity, displays a quote instead.

### DIFF
--- a/busy_beaver/tasks.py
+++ b/busy_beaver/tasks.py
@@ -24,4 +24,8 @@ def post_github_summary_to_slack(channel: str) -> None:
         logger.info("[Busy-Beaver] Compiling stats for {0}".format(user))
         message += github_stats.generate_summary(user, boundary_dt)
 
+    if message == "":
+        message = ('"If code falls outside version control, and no one is around to read it, '
+                   'does it make a sound?" - Zax Rosenberg')
+
     slack.post_message(message, channel_id=channel_info.id)


### PR DESCRIPTION
MVP of a quote when there's no github activity. Future advancements should be bite-sized issues.