### PR TITLE
Hot Fix: Revert Docker permissions

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -15,6 +15,7 @@ RUN groupadd -g 901 -r sivdev \
 EXPOSE 5100
 
 # Switch from root user for security
-USER sivdev_user
+# USER sivdev_user
+# TODO: as we are writing logs, we need to be root. find a better solution
 
 CMD ["uvicorn", "busy_beaver.backend:api", "--host", "0.0.0.0", "--port", "5100"]


### PR DESCRIPTION
Still writing logs inside the container, which I'm not a big fan of. At least we aren't using SQLite anymore.

Will fix logging later. We can revert Docker container permissions for now.