### PR TITLE
Cache requirements between builds

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -6,7 +6,6 @@ LABEL maintainer="Aly Sivji <alysivji@gmail.com>" \
 WORKDIR /app
 
 COPY requirements.txt requirements_dev.txt /tmp/
-COPY ./ /app
 
 RUN groupadd -g 901 -r sivdev \
     && useradd -g sivdev -r -u 901 sivdev_user \
@@ -16,5 +15,7 @@ EXPOSE 5100
 
 # Switch from root user for security
 USER sivdev_user
+
+COPY ./ /app
 
 CMD ["uvicorn", "busy_beaver.backend:api", "--host", "0.0.0.0", "--port", "5100"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -6,7 +6,6 @@ LABEL maintainer="Aly Sivji <alysivji@gmail.com>" \
 WORKDIR /app
 
 COPY requirements.txt /tmp/
-COPY ./ /app
 
 RUN groupadd -g 901 -r sivdev \
     && useradd -g sivdev -r -u 901 sivdev_user \
@@ -17,5 +16,6 @@ EXPOSE 5100
 # Switch from root user for security
 # USER sivdev_user
 # TODO: as we are writing logs, we need to be root. find a better solution
+COPY ./ /app
 
 CMD ["uvicorn", "busy_beaver.backend:api", "--host", "0.0.0.0", "--port", "5100"]


### PR DESCRIPTION
Placing the copy near the end will save the requirements build cache so each build doesn't trigger a brand new pip install.