### PR TITLE
Unit Tests for Slack Adapter

### DIFF
--- a/tests/adapters/cassettes/test_slack_get_channel_info.yaml
+++ b/tests/adapters/cassettes/test_slack_get_channel_info.yaml
@@ -1,0 +1,168 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      authorization:
+      - DUMMY
+      user-agent:
+      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
+    method: POST
+    uri: https://slack.com/api/channels.list
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+WVXW/aMBSG/4rlm91ARSAJH3esUKaVotHSdes0IZOcgEtsR7YDYxX/fTafycZE
+        u65dpd0Q++Dj8+a8T+x7LKa4oWUKBRxMCOcQK9z4co9piBv41Dsb9CuX5x4uYE4YmJAkPBTMzKka
+        bhJ2+RKIBpPnuHWvUvZ8310tIzKY0Jn9IyKxglVsDBwkiXehlMeUT+2a0mYjIU2165WA/uXtRsCQ
+        C8lITL/blTktakJkvoSQ4wNRBmwEMhtJJJ0Z3blFCWW7+TrDdiUn57rd7H1s31z07Pjs9rxT989b
+        dtzp+CXfa37AXwtYi4QGuHGPZyRObft6ghfnQk7RiHANEpk3QHNiR4EQ8erBZ6Ya0VRwnG2FmcRE
+        6aECbZq0LOAklYlQkN29iZKYBIAiIRHfVCpKiK0tKIopi2LCCigiUUT5uIAmIhxDMbG/yKTc0ZF5
+        0+IdsQ+0EOmbECUSIjPRAk0BEiRSjUSEmJC2SpAqs3GuyhaikyPiJcyoSNXQump7a5rFUzbcNdtd
+        FnYQdvq9wVWpuodwS89fo3Cd+kcQ5rS8QgrtuPuu235/MThI5KlgCeGL4pyGYHDkIuUBMOBareG0
+        5o6I9ZkRra2Ex1I5mFC15QKZoaVTA2HrkoFgLOU0WBG/KpkTcYKacbxajjYtQKaZiHKkM9s+lTZv
+        T1v79OpTq1W/3tM2StViBMR8lkMNSh+hznMrTtWtluvPe/YdFPUP8TuE1qNJeaKL5YyLN61a5XPV
+        zbtYXHfsqIOeU/Kr9fLzO5gT9MLuvQbHnL1jZ93WZbvfe5txTOiiZdtcVUcdqznlUsV5bsd+FvR/
+        O9bp+gOnXsuclIEIFw85Ij3HdRzXqz3Zrswt96tdeTUvfzY++Ap+tIcbCLe3H/5dT/Yb7Xpef4jJ
+        laWJSFCJ4ApMWJOQaGIVcPimh0Eq1VrrcvkDL45re0EMAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - slack-route, x-slack-version-ts
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - x-slack-req-id
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '719'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 31 Mar 2019 20:13:02 GMT
+      Expires:
+      - Mon, 26 Jul 1997 05:00:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 6ca6a5c7e4ef3511c3ea6d058e2252f9.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes:
+      - channels:read,read
+      X-Amz-Cf-Id:
+      - mI_qPeqopEbFp0FBGlcsvrChSMBCw1jnMXmq1H0dhelPdn3MbbavUQ==
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-OAuth-Scopes:
+      - identify,bot:basic
+      X-Slack-Req-Id:
+      - bf8060a5-439c-4d6c-bf6e-bc803589f895
+      X-Via:
+      - haproxy-www-b3u7
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: channel=C5GQNTS07
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '17'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      authorization:
+      - DUMMY
+      user-agent:
+      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
+    method: POST
+    uri: https://slack.com/api/channels.info
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VRXWvCMBT9KyHPTty0HfZNnHbMD+ZWN3BIie3VBvNRklRx4n9fUjtpYbC3e0/P
+        uef05IzlHgdGFdDCSUaEAIaDM6YpDvDQCxfz6L3ziFtYEA4W2oEARZgFqI5v/EqugBiwwvte3+s+
+        eL7fK2lEJRk9uA9bwjSU2O+dSloIRsXeUTrVHams29IbR4vu4m1VBYiFVJww+u2YzSxWk8ZSsFPd
+        RWdENX2l2v2BcuAbUHUkV/Rgf6ZByim/7VeFxsFXI+RyNJh/jD5nczePV5Ow70+e3ByGfsf3Bq/l
+        PH2ejl5mEV63sJE5TVzhB8IKV/BQ8pyI092RpoBsvbIQCXAQRtstRUep9ncboiFFnBjjItQLswsj
+        2sQajK3y0sJ5oXKpoe4QZVSj6umQHbdSIQOEXy0TyXkhaEIMlaK0bIRoowFjJR1VFSBbJqICmdrZ
+        9j+hFByoLHTs3tR1uL5cfgD8akn3iAIAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - slack-route, x-slack-version-ts
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - x-slack-req-id
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '367'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 31 Mar 2019 20:13:02 GMT
+      Expires:
+      - Mon, 26 Jul 1997 05:00:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 9beef7f4d5d93ab1724fe013eb38c198.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes:
+      - channels:read,read
+      X-Amz-Cf-Id:
+      - VxvuRjipOy9OhFaAtDO02RzTRlQPjO9_DV1MuLNgTlM0nYilvDpDpQ==
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-OAuth-Scopes:
+      - identify,bot:basic
+      X-Slack-Req-Id:
+      - f13a2ed8-2788-4843-999d-77339c071ee6
+      X-Via:
+      - haproxy-www-j0xn
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/adapters/cassettes/test_slack_post_message_success.yaml
+++ b/tests/adapters/cassettes/test_slack_post_message_success.yaml
@@ -1,0 +1,164 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      authorization:
+      - DUMMY
+      user-agent:
+      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
+    method: POST
+    uri: https://slack.com/api/channels.list
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+WVXW/aMBSG/4rlm91ARSAJH3esUKaVotHSdes0IZOcgEtsR7YDYxX/fTafycZE
+        u65dpd0Q++Dj8+a8T+x7LKa4oWUKBRxMCOcQK9z4co9piBv41Dsb9CuX5x4uYE4YmJAkPBTMzKka
+        bhJ2+RKIBpPnuHWvUvZ8310tIzKY0Jn9IyKxglVsDBwkiXehlMeUT+2a0mYjIU2165WA/uXtRsCQ
+        C8lITL/blTktakJkvoSQ4wNRBmwEMhtJJJ0Z3blFCWW7+TrDdiUn57rd7H1s31z07Pjs9rxT989b
+        dtzp+CXfa37AXwtYi4QGuHGPZyRObft6ghfnQk7RiHANEpk3QHNiR4EQ8erBZ6Ya0VRwnG2FmcRE
+        6aECbZq0LOAklYlQkN29iZKYBIAiIRHfVCpKiK0tKIopi2LCCigiUUT5uIAmIhxDMbG/yKTc0ZF5
+        0+IdsQ+0EOmbECUSIjPRAk0BEiRSjUSEmJC2SpAqs3GuyhaikyPiJcyoSNXQump7a5rFUzbcNdtd
+        FnYQdvq9wVWpuodwS89fo3Cd+kcQ5rS8QgrtuPuu235/MThI5KlgCeGL4pyGYHDkIuUBMOBareG0
+        5o6I9ZkRra2Ex1I5mFC15QKZoaVTA2HrkoFgLOU0WBG/KpkTcYKacbxajjYtQKaZiHKkM9s+lTZv
+        T1v79OpTq1W/3tM2StViBMR8lkMNSh+hznMrTtWtluvPe/YdFPUP8TuE1qNJeaKL5YyLN61a5XPV
+        zbtYXHfsqIOeU/Kr9fLzO5gT9MLuvQbHnL1jZ93WZbvfe5txTOiiZdtcVUcdqznlUsV5bsd+FvR/
+        O9bp+gOnXsuclIEIFw85Ij3HdRzXqz3Zrswt96tdeTUvfzY++Ap+tIcbCLe3H/5dT/Yb7Xpef4jJ
+        laWJSFCJ4ApMWJOQaGIVcPimh0Eq1VrrcvkDL45re0EMAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - slack-route, x-slack-version-ts
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - x-slack-req-id
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '719'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 31 Mar 2019 20:24:48 GMT
+      Expires:
+      - Mon, 26 Jul 1997 05:00:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 0e31b6655e8230805e58fd71c1351ba1.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes:
+      - channels:read,read
+      X-Amz-Cf-Id:
+      - pQMnscaLflvfWDd0x7xOYWZmo7Jq-gRLEDn4poiRmK7EZG-R2S4q3Q==
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-OAuth-Scopes:
+      - identify,bot:basic
+      X-Slack-Req-Id:
+      - 0ab3b7fa-bd5a-4a2d-93a4-e5321fbe0511
+      X-Via:
+      - haproxy-www-85xl
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: channel=C5GQNTS07&text=test
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      authorization:
+      - DUMMY
+      user-agent:
+      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
+    method: POST
+    uri: https://slack.com/api/chat.postMessage
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA33MQQvCMAyG4f+S85BUrc4dJzLwIMq8S6dhDl0nTSqOsf9uC6I3T4HnJd8A3Q0y
+        cZ4SOF+NtXSHDNa6OOyOJS4hAeEASus5LmZpupogokIMoSVmUxNkA0j/CPcrCbCvPlZ1cvq50EsC
+        CrH8m/ZMzpo2/uee+5zMk1wppm5sHXLcbC4xbrbTvFD7AsbxDbTQEBzKAAAA
+    headers:
+      Access-Control-Allow-Headers:
+      - slack-route, x-slack-version-ts
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - x-slack-req-id
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '159'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 31 Mar 2019 20:24:49 GMT
+      Expires:
+      - Mon, 26 Jul 1997 05:00:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 eece9b48dfd62f662117c631fa9b910f.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes:
+      - chat:write:bot,post
+      X-Amz-Cf-Id:
+      - v0d8VQuBBtlFKfR4CZsqi-_tVqm4ttcVLACd6xybR9JktwrbIVG8kg==
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-OAuth-Scopes:
+      - identify,bot:basic
+      X-Slack-Req-Id:
+      - bd7c6b88-3dd6-45ef-9349-bc01aba6713d
+      X-Via:
+      - haproxy-www-o93
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/adapters/github_test.py
+++ b/tests/adapters/github_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import os
 
 import pytest
 import pytz
@@ -10,12 +9,12 @@ from busy_beaver.adapters.github import (
     GitHubAdapter,
     page_from_url,
 )
+from busy_beaver.config import GITHUB_OAUTH_TOKEN
 
 
 @pytest.fixture
 def client():
-    oauth_token = os.getenv("GITHUB_OAUTH_TOKEN")
-    yield GitHubAdapter(oauth_token)
+    yield GitHubAdapter(oauth_token=GITHUB_OAUTH_TOKEN)
 
 
 @pytest.mark.vcr()

--- a/tests/adapters/slack_test.py
+++ b/tests/adapters/slack_test.py
@@ -1,0 +1,29 @@
+import pytest
+
+from busy_beaver.adapters.slack import SlackAdapter
+from busy_beaver.config import SLACK_TOKEN
+
+
+MODULE_TO_TEST = "busy_beaver.adapters.slack"
+
+
+@pytest.fixture(scope="module")
+def slack():
+    return SlackAdapter(SLACK_TOKEN)
+
+
+@pytest.mark.vcr()
+def test_slack_get_channel_info(slack: SlackAdapter):
+    # Act
+    result = slack.get_channel_info("general")
+
+    # Assert
+    assert result.name == "general"
+    assert isinstance(result.id, str)
+    assert len(result.members) > 0
+
+
+@pytest.mark.vcr()
+def test_slack_post_message_without_specifying_channel(slack: SlackAdapter):
+    with pytest.raises(ValueError):
+        slack.post_message(message="test")

--- a/tests/adapters/slack_test.py
+++ b/tests/adapters/slack_test.py
@@ -24,6 +24,16 @@ def test_slack_get_channel_info(slack: SlackAdapter):
 
 
 @pytest.mark.vcr()
+def test_slack_post_message_success(slack: SlackAdapter):
+    # Act
+    result = slack.post_message("test", channel="general")
+
+    # Assert
+    assert result["ok"] is True
+    assert result["message"]["text"] == "test"
+
+
+@pytest.mark.vcr()
 def test_slack_post_message_without_specifying_channel(slack: SlackAdapter):
     with pytest.raises(ValueError):
         slack.post_message(message="test")


### PR DESCRIPTION
This issue falls under #40 

Spent a few hours trying to think of a good way to test #98. I realized I needed to unit test the Slack adapter.

Started off using mocks, but noticed the Slack Client uses requests under the hood for the methods we use (`.api_call()`). Perfect use case for [VCR.py](http://vcrpy.readthedocs.io/en/latest/)!