### PR TITLE
Add integration test for hitting Twitter Poller endpoint

### DIFF
--- a/busy_beaver/blueprints/tasks/retweeter.py
+++ b/busy_beaver/blueprints/tasks/retweeter.py
@@ -27,7 +27,7 @@ class TwitterPollingResource(MethodView):
                 "[Busy-Beaver] Twitter Summary Poll -- need channel in JSON body"
             )
             return make_response(422, error={"message": "JSON requires 'channel' key"})
-        start_post_tweets_to_slack_task(user, channel=data["channel"])
+        start_post_tweets_to_slack_task(user, channel_name=data["channel"])
 
         logger.info("[Busy-Beaver] Twitter Summary Poll -- kicked-off")
         return make_response(200, json={"run": "complete"})

--- a/tests/blueprints/tasks/retweeter_test.py
+++ b/tests/blueprints/tasks/retweeter_test.py
@@ -1,5 +1,8 @@
 import pytest
+
 from busy_beaver.blueprints.tasks.retweeter import start_post_tweets_to_slack_task
+from busy_beaver.models import PostTweetTask
+from busy_beaver.tasks.retweeter import fetch_tweets_post_to_slack
 
 MODULE_TO_TEST = "busy_beaver.blueprints.tasks.retweeter"
 
@@ -13,8 +16,42 @@ def patched_retweeter_trigger(mocker, patcher):
     )
 
 
+##################
+# Integration Test
+##################
+@pytest.fixture
+def patched_background_task(patcher, create_fake_background_task):
+    return patcher(
+        "busy_beaver.tasks.retweeter",
+        namespace=fetch_tweets_post_to_slack.__name__,
+        replacement=create_fake_background_task(),
+    )
+
+
+@pytest.mark.integration
+def test_poll_twitter_smoke_test(
+    caplog, client, session, create_api_user, patched_background_task
+):
+    # Arrange
+    create_api_user(username="test_user", token="abcd", role="admin")
+
+    #  Act
+    client.post(
+        "/poll-twitter",
+        headers={"Authorization": "token abcd"},
+        json={"channel": "general"},
+    )
+
+    # Assert
+    tasks = PostTweetTask.query.all()
+    assert len(tasks) == 1
+
+
+###########
+# Unit Test
+###########
 @pytest.mark.unit
-def test_github_summary_endpoint_no_token(
+def test_poll_twitter_endpoint_no_token(
     client, session, create_api_user, patched_retweeter_trigger
 ):
     # Arrange
@@ -28,7 +65,7 @@ def test_github_summary_endpoint_no_token(
 
 
 @pytest.mark.unit
-def test_github_summary_endpoint_incorrect_token(
+def test_poll_twitter_endpoint_incorrect_token(
     client, session, create_api_user, patched_retweeter_trigger
 ):
     # Arrange
@@ -42,7 +79,7 @@ def test_github_summary_endpoint_incorrect_token(
 
 
 @pytest.mark.unit
-def test_github_summary_endpoint_empty_body(
+def test_poll_twitter_endpoint_empty_body(
     caplog, client, session, create_api_user, patched_retweeter_trigger
 ):
     # Arrange
@@ -56,7 +93,7 @@ def test_github_summary_endpoint_empty_body(
 
 
 @pytest.mark.unit
-def test_github_summary_endpoint_success(
+def test_poll_twitter_endpoint_success(
     caplog, client, session, create_api_user, patched_retweeter_trigger
 ):
     # Arrange
@@ -73,4 +110,4 @@ def test_github_summary_endpoint_success(
     # Assert
     assert result.status_code == 200
     args, kwargs = mock.call_args
-    assert kwargs["channel"] == "general"
+    assert kwargs["channel_name"] == "general"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,10 @@ References:
     - http://flask.pocoo.org/docs/1.0/testing/
 """
 
+from collections import namedtuple
 from datetime import timedelta
+import uuid
+
 import pytest
 
 from busy_beaver.adapters import KeyValueStoreAdapter
@@ -103,3 +106,35 @@ def create_api_user(session):
         return new_api_user
 
     return _new_api_user
+
+
+@pytest.fixture
+def create_fake_background_task():
+    """This fixture creates fake background jobs.
+
+    When `.queue` is called on a function decorated with `@rq.job`, it creates a
+    background job managed by python-rq and returns an object with job details.
+
+    This fixture creates a Fake that looks like an object created by python-rq. Used
+    this fixture to replace functions decorated with `@rq.job` so that we can unit test
+    "trigger" functions.
+
+    Unit test trigger functions by ensuring data that should be saved to database
+    actually is.
+    """
+    JobDetails = namedtuple("JobDetails", ["id"])
+
+    class FakeBackgroundTask:
+        def __init__(self):
+            self.id = str(uuid.uuid4())
+
+        def __repr__(self):
+            return f"<FakeBackgroundTask: {self.id}>"
+
+        def queue(self, *args, **kwargs):
+            return JobDetails(self.id)
+
+    def _create_fake_background_task():
+        return FakeBackgroundTask()
+
+    yield _create_fake_background_task

--- a/tests/tasks/conftest.py
+++ b/tests/tasks/conftest.py
@@ -1,6 +1,3 @@
-from collections import namedtuple
-import uuid
-
 import pytest
 
 from busy_beaver.models import User
@@ -15,38 +12,6 @@ def create_user(session):
         return new_user
 
     return _new_user
-
-
-@pytest.fixture
-def create_fake_background_task():
-    """This fixture creates fake background jobs.
-
-    When `.queue` is called on a function decorated with `@rq.job`, it creates a
-    background job managed by python-rq and returns an object with job details.
-
-    This fixture creates a Fake that looks like an object created by python-rq. Used
-    this fixture to replace functions decorated with `@rq.job` so that we can unit test
-    "trigger" functions.
-
-    Unit test trigger functions by ensuring data that should be saved to database
-    actually is.
-    """
-    JobDetails = namedtuple("JobDetails", ["id"])
-
-    class FakeBackgroundTask:
-        def __init__(self):
-            self.id = str(uuid.uuid4())
-
-        def __repr__(self):
-            return f"<FakeBackgroundTask: {self.id}>"
-
-        def queue(self, *args, **kwargs):
-            return JobDetails(self.id)
-
-    def _create_fake_background_task():
-        return FakeBackgroundTask()
-
-    yield _create_fake_background_task
 
 
 @pytest.fixture

--- a/tests/tasks/retweeter_test.py
+++ b/tests/tasks/retweeter_test.py
@@ -26,7 +26,7 @@ def patched_background_task(patcher, create_fake_background_task):
 
 
 @pytest.mark.unit
-def test_start_post_tweet_task(session, patched_background_task, create_api_user):
+def test_start_post_tweet_task(session, create_api_user, patched_background_task):
     """Test trigger function"""
     # Arrange
     api_user = create_api_user("admin")


### PR DESCRIPTION
Changed a function parameter name and things broke. We only had unit tests versus integration tests to ensure the system as a whole worked as intended.

Live and learn.