### PR TITLE
Use ENTRYPOINT script to start process inside container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,7 +46,7 @@ services:
   # busy-beaver business logic
   app:
     image: alysivji/busy-beaver:latest
-    command: ["gunicorn", "busy_beaver:create_app()", "-b", "0.0.0.0:5000"]
+    command: webserver
     environment: &app_env_vars
       IN_PRODUCTION: 1
       PYTHONPATH: .
@@ -77,7 +77,7 @@ services:
       - traefik.port=5000
   worker:
     image: alysivji/busy-beaver:latest
-    command: ["python", "start_async_worker.py"]
+    command: worker
     environment: *app_env_vars
     volumes: *app_volumes
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     depends_on: &app_depends_on
       - db
     environment: &app_env_vars
+      IN_PRODUCTION: 0
       PYTHONPATH: .
       FLASK_APP: /app/busy_beaver/__init__.py
       FLASK_ENV: development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     build: &app_build
       context: .
       dockerfile: ./docker/dev/Dockerfile
-    command: ["gunicorn", "busy_beaver:create_app()", "-b", "0.0.0.0:5000", "--reload", "--timeout",  "100000"]
+    command: webserver
     env_file: .env
     depends_on: &app_depends_on
       - db
@@ -55,7 +55,7 @@ services:
     tty: true
   worker:
     build: *app_build
-    command: ["python", "start_async_worker.py"]
+    command: worker
     env_file: .env
     depends_on: *app_depends_on
     environment: *app_env_vars

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -11,11 +11,11 @@ RUN groupadd -g 901 -r sivdev \
     && useradd -g sivdev -r -u 901 sivdev_user \
     && pip install --no-cache-dir -r /tmp/requirements_dev.txt
 
-EXPOSE 5100
+EXPOSE 5000
 
 # Switch from root user for security
 # USER sivdev_user
 
 COPY ./ /app
 
-CMD ["gunicorn", "busy_beaver:app", "-b", "0.0.0.0:5100"]
+ENTRYPOINT [ "scripts/entrypoint.sh" ]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -11,11 +11,11 @@ RUN groupadd -g 901 -r sivdev \
     && useradd -g sivdev -r -u 901 sivdev_user \
     && pip install --no-cache-dir -r /tmp/requirements.txt
 
-EXPOSE 5100
+EXPOSE 5000
 
 # Switch from root user for security
 # USER sivdev_user
 # TODO: as we are writing logs, we need to be root. find a better solution
 COPY ./ /app
 
-CMD ["gunicorn", "busy_beaver:app", "-b", "0.0.0.0:5100"]
+ENTRYPOINT [ "scripts/entrypoint.sh" ]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 if [ "$1" = "webserver" ]; then
     echo "Starting Flask server"
     flask db upgrade
@@ -13,5 +14,3 @@ elif [ "$1" = "worker" ]; then
 else
     exit 1
 fi
-
-exec $CMD "$@"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,16 +1,29 @@
 #!/bin/bash
+# Set strict mode options
+set -euo pipefail
 
-if [ "$1" = "webserver" ]; then
+# Set default value for the server
+DEFAULT="webserver"
+SERVER=${1:-$DEFAULT}
+
+# Set a default value for production status
+PRODUCTION=${IN_PRODUCTION:-0}
+
+if [ "$SERVER" = "webserver" ]; then
     echo "Starting Flask server"
-    flask db upgrade
-    if [ "$IN_PRODUCTION" = 1 ]; then
+    # flask db upgrade
+    if [ "$PRODUCTION" = 1 ]; then
         gunicorn "busy_beaver:create_app()" -b 0.0.0.0:5000
-    else
+    elif [ "$PRODUCTION" = 0 ]; then
         gunicorn "busy_beaver:create_app()" -b 0.0.0.0:5000 --reload --timeout 100000
+    else
+        echo "Unrecognized option for variable IN_PRODUCTION: '$PRODUCTION'"
+        exit 1
     fi
-elif [ "$1" = "worker" ]; then
+elif [ "$SERVER" = "worker" ]; then
     echo "Starting RQ worker"
     python start_async_worker.py
 else
+    echo "Unrecognized option for server: '$SERVER'"
     exit 1
 fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+if [ "$1" = "webserver" ]; then
+    echo "Starting Flask server"
+    flask db upgrade
+    if [ "$IN_PRODUCTION" = 1 ]; then
+        gunicorn "busy_beaver:create_app()" -b 0.0.0.0:5000
+    else
+        gunicorn "busy_beaver:create_app()" -b 0.0.0.0:5000 --reload --timeout 100000
+    fi
+elif [ "$1" = "worker" ]; then
+    echo "Starting RQ worker"
+    python start_async_worker.py
+else
+    exit 1
+fi
+
+exec $CMD "$@"


### PR DESCRIPTION
Unfortunately, I've had to log into my droplet to run migrations every time we change the database schema.

The easiest solution is to create an `ENTRYPOINT` script that runs migrations for us automatically each time the container restarts.

References:
- [Dockerfile: `ENTRYPOINT` vs `CMD`](https://www.ctl.io/developers/blog/post/dockerfile-entrypoint-vs-cmd/)